### PR TITLE
Allow ticket attachments

### DIFF
--- a/lib/freshdesk/resource.rb
+++ b/lib/freshdesk/resource.rb
@@ -30,7 +30,11 @@ module Freshdesk
     end
 
     def post
-      @resource.post(json_payload, content_type: "application/json")
+      attachments = @params.keys.map(&:to_s).include?('attachments')
+      options = attachments ? {} : { content_type: 'application/json' }
+      payload = attachments ? @params : json_payload
+
+      @resource.post(payload, options)
     rescue RestClient::Exception => e
       raise e, api_error_message(e)
     end


### PR DESCRIPTION
Passing an array of files is possible within the params, however
if that happens the POST shouldn't happen as a JSON.

Checking if the params have the attachments key, and then
posting as JSON or as a multi form depending on the case.